### PR TITLE
 Appveyor: fix vcpkg dependcies, set Visual Studio base image as matrix 

### DIFF
--- a/Dependencies.txt
+++ b/Dependencies.txt
@@ -1,17 +1,16 @@
 ﻿這份文件說明開發和釋出的需求
 
-- [開發] Visual Studio 2017 (Community 即可)
+- [開發] Visual Studio 2017/2019 (Community 即可)
 
 請至官方網站下載: https://www.visualstudio.com/
 
-- [開發] cpprestsdk
+- [開發] cpprestsdk (須包含 websockets 這個 feature)
 
-這兩個推薦使用 vcpkg 安裝, 安裝說明請至以下網站:
+推薦使用 vcpkg 安裝, 安裝說明請至以下網站:
 https://github.com/Microsoft/vcpkg
 
-安裝指令: vcpkg install cpprestsdk
+安裝指令: vcpkg install cpprestsdk[default-features,websockets]
 
-- [釋出] Microsoft Visual C++ Redistributable for Visual Studio 2017 (或相對應的版本)
+- [釋出] Microsoft Visual C++ Redistributable for Visual Studio 2017/2019 (或相對應的版本)
 
-可至 https://www.visualstudio.com/downloads/ 的
-Other Tools and Frameworks 區域下載.
+可至 https://www.visualstudio.com/downloads/ 的 Other Tools and Frameworks 區域下載.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: '{build}'
-image: Visual Studio 2017
+image: 
+  - Visual Studio 2017
+  - Visual Studio 2019
 configuration: Release
 init:
 - ps: Set-Culture zh-TW
@@ -10,7 +12,7 @@ install:
 - .\bootstrap-vcpkg.bat
 - cd "%APPVEYOR_BUILD_FOLDER%"
 - vcpkg remove --outdated --recurse
-- vcpkg install cpprestsdk
+- vcpkg install cpprestsdk[default-features,websockets]
 
 - ps: .\Scripts\BeforeBuild.ps1
 clone_folder: C:\projects\pcman-windows


### PR DESCRIPTION
* Fix vcpkg name to `cpprestsdk[default-features,websockets]`
  - The reason of package default features changes:
    + https://github.com/microsoft/vcpkg/pull/10478
    + https://github.com/microsoft/vcpkg/commit/056e9517ec7c461cdfabe8ff73124325708a4723
* Let AppVeyor test both Visual Studio 2017/2019 environment